### PR TITLE
Torque stuff

### DIFF
--- a/Player/TorquePlayer.gd
+++ b/Player/TorquePlayer.gd
@@ -1,0 +1,31 @@
+extends RigidBody2D
+
+export var target_movement_time = 0.2
+export var target_accel_time = 0.1
+export var max_torque: float = 1000
+
+func look_follow(current_position, target_position):
+	var target_angle = atan2(target_position.y - current_position.y, target_position.x - current_position.x)
+	var current_angle = rotation
+	var difference = target_angle - current_angle
+
+	if difference > PI:
+		difference -= PI * 2
+	elif difference < -PI:
+		difference += PI * 2
+
+	attempt_angular_velocity(difference / target_movement_time)
+
+# func _integrate_forces(state):
+func _physics_process(_delta):
+	look_follow(global_position, get_global_mouse_position())
+
+func _input(event):
+	if event is InputEventMouseButton and event.button_index == BUTTON_LEFT and event.pressed:
+		var impulse_vector = Vector2(100, 0).rotated(rotation)
+		apply_impulse(Vector2(), impulse_vector)
+
+func attempt_angular_velocity(target_velocity: float):
+	var target_acceleration = (target_velocity - angular_velocity) / target_accel_time
+	var target_torque = inertia * target_acceleration
+	add_torque(clamp(target_torque, -max_torque, max_torque))

--- a/Player/TorquePlayer.tscn
+++ b/Player/TorquePlayer.tscn
@@ -1,0 +1,21 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://Player/TorquePlayer.gd" type="Script" id=1]
+
+[sub_resource type="RectangleShape2D" id=2]
+extents = Vector2( 33.3566, 33.7604 )
+
+[node name="TorquePlayer" type="RigidBody2D"]
+position = Vector2( 96, 16 )
+angular_damp = 10.417
+script = ExtResource( 1 )
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+scale = Vector2( 0.59933, 0.587948 )
+shape = SubResource( 2 )
+
+[node name="ColorRect" type="ColorRect" parent="."]
+margin_left = -20.0
+margin_top = -20.0
+margin_right = 20.0
+margin_bottom = 20.0

--- a/World/World.tscn
+++ b/World/World.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=4 format=2]
 
 [ext_resource path="res://Player/RigidPlayer.tscn" type="PackedScene" id=1]
+[ext_resource path="res://Player/TorquePlayer.tscn" type="PackedScene" id=2]
 
 [sub_resource type="RectangleShape2D" id=1]
 extents = Vector2( 100000, 100000 )
@@ -34,3 +35,5 @@ position = Vector2( 416, 24 )
 current = true
 limit_top = -20
 smoothing_enabled = true
+
+[node name="TorquePlayer" parent="." instance=ExtResource( 2 )]


### PR DESCRIPTION
Creating a separate TorquePlayer like RigidPlayer, but that rotates using added torque instead of direct angular velocity manipulation. This _should_ play nicer with other physics objects.

Box on the left is TorquePlayer, box on the right is old RigidPlayer.

https://github.com/its-dlh/brackeys-2023.2/assets/2491467/948efdeb-7477-4ad5-9d35-1c0c705cdbb8

